### PR TITLE
Add support for filtering

### DIFF
--- a/cmd/rcloneui/rcloneui.go
+++ b/cmd/rcloneui/rcloneui.go
@@ -19,12 +19,20 @@ import (
 )
 
 var (
+	maxAge      string
+	maxSize     string
+	minAge      string
+	minSize     string
 	showVersion bool
 )
 
 // init is used to define all flags for rcloneui. For example we define the --version flag here, which can be used to
 // print the version information of rcloneui.
 func init() {
+	flag.StringVar(&maxAge, "max-age", "off", "Only transfer files younger than this in s or suffix ms|s|m|h|d|w|M|y.")
+	flag.StringVar(&maxSize, "max-size", "off", "Only transfer files smaller than this in k or suffix b|k|M|G.")
+	flag.StringVar(&minAge, "min-age", "off", "Only transfer files older than this in s or suffix ms|s|m|h|d|w|M|y.")
+	flag.StringVar(&minSize, "min-size", "off", "Only transfer files bigger than this in k or suffix b|k|M|G.")
 	flag.BoolVar(&showVersion, "version", false, "Print version information.")
 }
 
@@ -59,9 +67,14 @@ func main() {
 	// initialized we have to pass the other view to a view, so that we can switch the focus via the tab key.
 	app := tview.NewApplication()
 
+	filter, err := view.CreateFilter(minAge, maxAge, minSize, maxSize)
+	if err != nil {
+		log.Fatalf("Could not create filter: %#v", err)
+	}
+
 	status := view.NewStatus(app)
-	view1 := view.NewView(app, status, remotes, strings.Split(userDir, "/"))
-	view2 := view.NewView(app, status, remotes, strings.Split(userDir, "/"))
+	view1 := view.NewView(app, status, remotes, strings.Split(userDir, "/"), filter)
+	view2 := view.NewView(app, status, remotes, strings.Split(userDir, "/"), filter)
 
 	view1.SetView(view2)
 	view2.SetView(view1)

--- a/pkg/view/helpers.go
+++ b/pkg/view/helpers.go
@@ -3,6 +3,9 @@ package view
 import (
 	"fmt"
 	"strings"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/filter"
 )
 
 // fsPath checks the remote and if it is the special local "remote" we just return the path instead of the remote:path
@@ -19,4 +22,66 @@ func fsPath(remote string, path []string) string {
 // file so that we can remove the filename from the path for the rclone operations.
 func fsPathFilename(path []string) ([]string, string) {
 	return path[:len(path)-1], path[len(path)-1]
+}
+
+// CreateFilter returns a filter with the given min/max age and size.
+func CreateFilter(minAge, maxAge, minSize, maxSize string) (*filter.Filter, error) {
+	minAgeParsed, err := parseDuration(minAge)
+	if err != nil {
+		return nil, err
+	}
+
+	maxAgeParsed, err := parseDuration(maxAge)
+	if err != nil {
+		return nil, err
+	}
+
+	minSizeParsed, err := parseSize(minSize)
+	if err != nil {
+		return nil, err
+	}
+
+	maxSizeParsed, err := parseSize(maxSize)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := filter.Opt{
+		MinAge:  minAgeParsed,
+		MaxAge:  maxAgeParsed,
+		MinSize: minSizeParsed,
+		MaxSize: maxSizeParsed,
+	}
+
+	return filter.NewFilter(&opts)
+}
+
+// parseDuration parses the given duration string and returns it in the fs.Duration format, which can be used in the
+// filter options.
+func parseDuration(duration string) (fs.Duration, error) {
+	if duration == "off" {
+		return fs.DurationOff, nil
+	}
+
+	parsed, err := fs.ParseDuration(duration)
+	if err != nil {
+		return fs.DurationOff, err
+	}
+
+	return fs.Duration(parsed), nil
+}
+
+// parseSize parses the given size and returns it in the fs.SizeSuffix format, which can be used in the filter options.
+func parseSize(size string) (fs.SizeSuffix, error) {
+	if size == "off" {
+		return fs.SizeSuffix(-1), nil
+	}
+
+	sizeSuffix := fs.SizeSuffix(-1)
+	err := sizeSuffix.Set(size)
+	if err != nil {
+		return sizeSuffix, err
+	}
+
+	return sizeSuffix, nil
 }


### PR DESCRIPTION
This commit adds support for filtering via the "--min-age", "--max-age",
"--min-size" and "--max-size" flags. These values can only be set via
flags and they are applied for all remotes. The default value for all
flags is "off" and they are using the same format as the corresponding
rclone flags.

NOTE: Maybe we can add a modal to set these flags during the runtime of
the rcloneui.

Closes #4.